### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/next_frontend.yml
+++ b/.github/workflows/next_frontend.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Next Frontend Tests
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/roterpanda/timeregistry/security/code-scanning/2](https://github.com/roterpanda/timeregistry/security/code-scanning/2)

To fix the issue, we need to add a `permissions` key to the workflow. Since the workflow primarily involves testing (`checkout`, `setup-node`, `linting`, and `building`), it does not require write permissions. Therefore, we should set the `contents` permission to `read` for the entire workflow. This will limit the `GITHUB_TOKEN` to the least privileges necessary.

The `permissions` block should be added at the root of the workflow (right after the `name` field) to apply it globally to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
